### PR TITLE
Add Deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# **DEPRECATED** - New releases (`>= 3.0.0`) are only available in the new [spec-repo](https://github.com/bitmovin/cocoapod-specs)!
+# **DEPRECATED** - This repository is deprecated in favour of our new [spec-repo](https://github.com/bitmovin/cocoapod-specs)! 
+
+## The new repository contains all `v2` versions which are available in this repository, as well as additional releases of the new major version (`3.0.0`).
 
 # bitmovin-player-ios-sdk-cocoapod
 This repository contains all released versions of the Bitmovin Player iOS SDK.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## The new repository contains all `v2` versions which are available in this repository, as well as additional releases of the new major version (`3.0.0`).
 
 # bitmovin-player-ios-sdk-cocoapod
-This repository contains all released versions of the Bitmovin Player iOS SDK.
+This repository contains all released versions of the Bitmovin Player iOS SDK up to 2.x.
 
 ## Sample Applications
 Find some sample applications using the Bitmovin Player iOS SDK in our [sample repository](https://github.com/bitmovin/bitmovin-player-ios-samples).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# **DEPRECATED** - New releases (`>= 3.0.0`) are only available in the new [spec-repo](https://github.com/bitmovin/cocoapod-specs)!
+
 # bitmovin-player-ios-sdk-cocoapod
 This repository contains all released versions of the Bitmovin Player iOS SDK.
 


### PR DESCRIPTION
## Description
Releases starting with `3.0.0` are no longer pushed to this repository. They are only pushed to the new [spec-repo](https://github.com/bitmovin/cocoapod-specs).

_Future `v2` releases are still pushed to this repo._